### PR TITLE
HaydnOp20Dataset

### DIFF
--- a/muspy/datasets/__init__.py
+++ b/muspy/datasets/__init__.py
@@ -21,6 +21,7 @@ Base Classes
 Dataset Classes
 ---------------
 - EssenFolkSongDatabase
+- HaydnOp20Dataset
 - HymnalDataset
 - HymnalTuneDataset
 - JSBChoralesDataset
@@ -48,6 +49,7 @@ from .base import (
     RemoteMusicDataset,
 )
 from .essen import EssenFolkSongDatabase
+from .haydn import HaydnOp20Dataset
 from .hymnal import HymnalDataset, HymnalTuneDataset
 from .jsb import JSBChoralesDataset
 from .lmd import (
@@ -68,6 +70,7 @@ __all__ = [
     "DatasetInfo",
     "EssenFolkSongDatabase",
     "FolderDataset",
+    "HaydnOp20Dataset",
     "HymnalDataset",
     "HymnalTuneDataset",
     "JSBChoralesDataset",

--- a/muspy/datasets/haydn.py
+++ b/muspy/datasets/haydn.py
@@ -1,0 +1,59 @@
+"""Haydn Op.20 Dataset."""
+from pathlib import Path
+from typing import Union
+
+from ..inputs import from_music21
+from ..music import Music
+from .base import DatasetInfo, RemoteFolderDataset
+
+import music21
+
+_NAME = "Haydn Op.20 Dataset."
+_DESCRIPTION = """\
+This dataset is a set of functional harmonic analysis annotations \
+for the Op.20 string quartets from Joseph Haydn, commonly known as \
+the 'Sun' quartets."""
+_HOMEPAGE = "https://doi.org/10.5281/zenodo.1095630"
+_CITATION = """\
+@dataset{nestor_napoles_lopez_2017_1095630, \
+  author       = {N\'apoles L\'opez, N\'estor}, \
+  title        = {{Joseph Haydn - String Quartets Op.20 - Harmonic \
+                   Analysis Annotations Dataset}}, \
+  month        = dec, \
+  year         = 2017, \
+  publisher    = {Zenodo}, \
+  version      = {v1.1-alpha}, \
+  doi          = {10.5281/zenodo.1095630}, \
+  url          = {https://doi.org/10.5281/zenodo.1095630} \
+}"""
+
+
+class HaydnOp20Dataset(RemoteFolderDataset):
+    """Haydn Op.20 Dataset."""
+
+    _info = DatasetInfo(_NAME, _DESCRIPTION, _HOMEPAGE)
+    _citation = _CITATION
+    _sources = {
+        "haydn": {
+            "filename": "haydnop20v1.3_annotated.zip",
+            "url": (
+                "https://github.com/napulen/haydn_op20_harm/releases/download/v1.3/haydnop20v1.3_annotated.zip"
+            ),
+            "archive": True,
+            "size": 130954,
+            "md5": "1c65c8da312e1c9dda681d0496bf527f",
+            "sha256": "96986cccebfd37a36cc97a2fc0ebcfbe22d5136e622b21e04ea125d589f5073b"
+        }
+    }
+    _extension = "hrm"
+
+    def read(self, filename: Union[str, Path]) -> Music:
+        """Read a file into a Music object."""
+        s = music21.converter.parse(filename, format='humdrum')
+        # Getting the annotations
+        rna = list(s.flat.getElementsByClass('RomanNumeral'))
+        # Remove the annotations from the original score
+        # (they mess with the python representation)
+        s.remove(rna, recurse=True)
+        music = from_music21(s)
+        return music

--- a/muspy/datasets/haydn.py
+++ b/muspy/datasets/haydn.py
@@ -2,7 +2,7 @@
 from pathlib import Path
 from typing import Union
 
-from ..inputs import from_music21
+from ..inputs import from_music21_score
 from ..music import Music
 from .base import DatasetInfo, RemoteFolderDataset
 
@@ -55,5 +55,5 @@ class HaydnOp20Dataset(RemoteFolderDataset):
         # Remove the annotations from the original score
         # (they mess with the python representation)
         s.remove(rna, recurse=True)
-        music = from_music21(s)
+        music = from_music21_score(s)
         return music

--- a/muspy/datasets/wrapper.py
+++ b/muspy/datasets/wrapper.py
@@ -3,6 +3,7 @@ from typing import Type
 
 from .base import Dataset
 from .essen import EssenFolkSongDatabase
+from .haydn import HaydnOp20Dataset
 from .hymnal import HymnalDataset, HymnalTuneDataset
 from .jsb import JSBChoralesDataset
 from .lmd import (
@@ -27,6 +28,7 @@ def list_datasets():
     """
     return [
         EssenFolkSongDatabase,
+        HaydnOp20Dataset,
         HymnalDataset,
         HymnalTuneDataset,
         JSBChoralesDataset,
@@ -58,6 +60,8 @@ def get_dataset(key: str) -> Type[Dataset]:
     key = key.lower()
     if key == "essen":
         return EssenFolkSongDatabase
+    if key == 'haydn':
+        return HaydnOp20Dataset
     if key.startswith("hymnal"):
         if key == "hymnal":
             return HymnalDataset

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -8,6 +8,7 @@ import tensorflow as tf
 import muspy
 from muspy import (
     EssenFolkSongDatabase,
+    HaydnOp20Dataset,
     HymnalDataset,
     HymnalTuneDataset,
     JSBChoralesDataset,
@@ -29,6 +30,7 @@ from muspy import (
 def test_get_dataset():
     answers = [
         ("essen", EssenFolkSongDatabase),
+        ("haydn", HaydnOp20Dataset),
         ("hymnal", HymnalDataset),
         ("hymnal-tune", HymnalTuneDataset),
         ("jsb", JSBChoralesDataset),
@@ -52,7 +54,7 @@ def test_get_dataset():
 
 
 def test_list_datasets():
-    assert len(list_datasets()) == 13
+    assert len(list_datasets()) == 14
 
 
 def test_music21():


### PR DESCRIPTION
An initial PR to add the `HaydnOp20Dataset` from the MTG.

This dataset is useful for symbolic music analysis or conditional generation based on harmony, rather than just generation (only 24 pieces of music).

The `annotations` portion of the `Music` object is still empty in the current PR. These are just a few lines away in the `read` function from being included.

Any recommendations for the format of the `annotations`?

I was considering something like

```python
"annotations": [
    {
        "time": 0,
        "annotation": {
            "key": "F#",
            "figure": "I",
            "chord": "F#maj"
        }
    },
    {
        "time": 24,
        "annotation": {
            "key": "F#",
            "figure": "V7",
            "chord": "C#7"
        }
    },
    ...
],
```
