### PR TITLE
Fix case when time shift is multiple of max_time_shift

### DIFF
--- a/muspy/outputs/event.py
+++ b/muspy/outputs/event.py
@@ -117,7 +117,8 @@ def to_event_representation(
             div, mod = divmod(time - time_cursor, max_time_shift)
             for _ in range(div):
                 events.append(offset_time_shift + max_time_shift - 1)
-            events.append(offset_time_shift + mod - 1)
+            if mod > 0:
+                events.append(offset_time_shift + mod - 1)
             events.append(code)
             time_cursor = time
         else:


### PR DESCRIPTION
I think this line will emit a spurious note-off for note 127 whenever the time difference is a multiple of `max_time_shift` (i.e. `mod == 0`). This PR fixes that problem.