### PR TITLE
Merging objects

### DIFF
--- a/muspy/base.py
+++ b/muspy/base.py
@@ -175,8 +175,8 @@ class Base:
             Whether to skip attributes with value None or those that are
             empty lists. Defaults to True.
         deepcopy : bool
-            Whether to make deep copies of attributes whose type is not
-            a MusPy class. Defaults to True.
+            Whether to make deep copies of the attributes. Defaults to
+            False.
 
         Returns
         -------
@@ -198,10 +198,10 @@ class Base:
                         )
                         for v in value
                     ]
+                elif deepcopy:
+                    ordered_dict[attr] = copy.deepcopy(value)
                 else:
-                    ordered_dict[attr] = (
-                        copy.deepcopy(value) if deepcopy else value
-                    )
+                    ordered_dict[attr] = value
             elif value is None:
                 if not skip_missing:
                     ordered_dict[attr] = None
@@ -209,10 +209,10 @@ class Base:
                 ordered_dict[attr] = value.to_ordered_dict(
                     skip_missing=skip_missing, deepcopy=deepcopy
                 )
+            elif deepcopy:
+                ordered_dict[attr] = copy.deepcopy(value)
             else:
-                ordered_dict[attr] = (
-                    copy.deepcopy(value) if deepcopy else value
-                )
+                ordered_dict[attr] = value
         return ordered_dict
 
     def copy(self: BaseType) -> BaseType:

--- a/muspy/base.py
+++ b/muspy/base.py
@@ -115,17 +115,8 @@ class Base:
                 return False
         return True
 
-    def __copy__(self: BaseType) -> BaseType:
-        # NOTE: We need skip_missing=False to avoid creating a new
-        # empty list
-        ordered_dict = self.to_ordered_dict(skip_missing=False)
-        return self.from_dict(ordered_dict)
-
     def __deepcopy__(self: BaseType, memo: Optional[dict]) -> BaseType:
-        # NOTE: We need skip_missing=False to avoid creating a new
-        # empty list
-        ordered_dict = self.to_ordered_dict(skip_missing=False, deepcopy=True)
-        return self.from_dict(ordered_dict)
+        return self.from_dict(self.to_ordered_dict())
 
     @classmethod
     def from_dict(cls: Type[BaseType], dict_: Mapping) -> BaseType:
@@ -162,7 +153,7 @@ class Base:
         return cls(**kwargs)
 
     def to_ordered_dict(
-        self, skip_missing: bool = True, deepcopy: bool = False,
+        self, skip_missing: bool = True, deepcopy: bool = True,
     ) -> OrderedDict:
         """Return the object as an OrderedDict.
 
@@ -176,7 +167,7 @@ class Base:
             empty lists. Defaults to True.
         deepcopy : bool
             Whether to make deep copies of the attributes. Defaults to
-            False.
+            True.
 
         Returns
         -------
@@ -216,12 +207,28 @@ class Base:
         return ordered_dict
 
     def copy(self: BaseType) -> BaseType:
-        """Return a shallow copy of the object."""
-        return self.__copy__()
+        """Return a shallow copy of the object.
+
+        This is equivalent to :py:func:`copy.copy(self)`.
+
+        Returns
+        -------
+        Shallow copy of the object.
+
+        """
+        return copy.copy(self)
 
     def deepcopy(self: BaseType) -> BaseType:
-        """Return a deep copy of the object."""
-        return self.__deepcopy__(memo=None)
+        """Return a deep copy of the object.
+
+        This is equivalent to :py:func:`copy.deepcopy(self)`
+
+        Returns
+        -------
+        Deep copy of the object.
+
+        """
+        return copy.deepcopy(self)
 
     def pretty_str(self, skip_missing: bool = True) -> str:
         """Return the attributes as a string in a YAML-like format.
@@ -243,7 +250,9 @@ class Base:
             Print the attributes in a YAML-like format.
 
         """
-        return yaml_dump(self.to_ordered_dict(skip_missing=skip_missing))
+        return yaml_dump(
+            self.to_ordered_dict(skip_missing=skip_missing, deepcopy=False)
+        )
 
     def print(self, skip_missing: bool = True):
         """Print the attributes in a YAML-like format.

--- a/muspy/core.py
+++ b/muspy/core.py
@@ -201,13 +201,21 @@ def sort(obj: ComplexBase) -> ComplexBase:
     return obj.sort()
 
 
-def to_ordered_dict(obj: Base, ignore_null: bool = True) -> OrderedDict:
+def to_ordered_dict(
+    obj: Base, ignore_null: bool = True, copy: bool = True
+) -> OrderedDict:
     """Return an OrderedDict converted from a Music object.
 
     Parameters
     ----------
     obj : :class:`muspy.Base`
         Object to convert.
+    ignore_null : bool
+        Whether to skip attributes with value None or those that are
+        empty lists. Defaults to True.
+    copy : bool
+        Whether to make deep copies of attributes whose type is not
+        a MusPy class. Defaults to True.
 
     Returns
     -------
@@ -215,7 +223,7 @@ def to_ordered_dict(obj: Base, ignore_null: bool = True) -> OrderedDict:
         Converted OrderedDict.
 
     """
-    return obj.to_ordered_dict(ignore_null)
+    return obj.to_ordered_dict(skip_none=ignore_null, copy=copy)
 
 
 def transpose(

--- a/muspy/core.py
+++ b/muspy/core.py
@@ -93,10 +93,12 @@ def adjust_time(obj: Base, func: Callable[[int], int]) -> Base:
 def append(obj1: ComplexBase, obj2) -> ComplexBase:
     """Append an object to the correseponding list.
 
+    This will automatically determine the list attributes to append
+    based on the type of the object.
+
     Parameters
     ----------
-    obj1 : :class:`muspy.Music`, :class:`muspy.Track` or \
-            :class:`muspy.Tempo`
+    obj1 : :class:`muspy.ComplexBase`
         Object to which `obj2` to append.
     obj2
         Object to be appended to `obj1`.
@@ -104,17 +106,43 @@ def append(obj1: ComplexBase, obj2) -> ComplexBase:
     Notes
     -----
     - If `obj1` is of type :class:`muspy.Music`, `obj2` can be
-      :class:`muspy.KeySignature`, :class:`muspy.TimeSignature`,
-      :class:`muspy.Lyric`, :class:`muspy.Annotation` or
-      :class:`muspy.Track`.
+      :class:`muspy.Tempo`, :class:`muspy.KeySignature`,
+      :class:`muspy.TimeSignature`, :class:`muspy.Lyric`,
+      :class:`muspy.Annotation` or :class:`muspy.Track`.
     - If `obj1` is of type :class:`muspy.Track`, `obj2` can be
-      :class:`muspy.Note`, :class:`muspy.Lyric` or
-      :class:`muspy.Annotation`.
-    - If `obj1` is of type :class:`muspy.Timing`, `obj2` can be
-      :class:`muspy.Tempo`.
+      :class:`muspy.Note`, :class:`muspy.Chord`,
+      :class:`muspy.Lyric` or :class:`muspy.Annotation`.
+
+    See Also
+    --------
+    :class:`muspy.ComplexBase.append` : Equivalent function.
 
     """
     return obj1.append(obj2)
+
+
+def extend(obj1: ComplexBase, obj2, deepcopy: bool = False) -> ComplexBase:
+    """Extend the list(s) with another object or iterable.
+
+    Parameters
+    ----------
+    obj1 : :class:`muspy.ComplexBase`
+        Object to extend.
+    obj2
+        If an object of the same type as `obj1` is given, extend the
+        list attributes with the corresponding list attributes of
+        `obj2`. If an iterable is given, call `obj1.append` on each
+        item.
+    deepcopy : bool
+        Whether to make deep copies of the appended objects. Defaults
+        to False.
+
+    See Also
+    --------
+    :class:`muspy.ComplexBase.extend` : Equivalent function.
+
+    """
+    return obj1.extend(obj2, deepcopy=deepcopy)
 
 
 def clip(
@@ -202,7 +230,7 @@ def sort(obj: ComplexBase) -> ComplexBase:
 
 
 def to_ordered_dict(
-    obj: Base, skip_missing: bool = True, copy: bool = True
+    obj: Base, skip_missing: bool = True, deepcopy: bool = True
 ) -> OrderedDict:
     """Return an OrderedDict converted from a Music object.
 
@@ -213,9 +241,9 @@ def to_ordered_dict(
     skip_missing : bool
         Whether to skip attributes with value None or those that are
         empty lists. Defaults to True.
-    copy : bool
-        Whether to make deep copies of attributes whose type is not
-        a MusPy class. Defaults to True.
+    deepcopy : bool
+        Whether to make deep copies of the attributes. Defaults to
+        False.
 
     Returns
     -------
@@ -223,7 +251,7 @@ def to_ordered_dict(
         Converted OrderedDict.
 
     """
-    return obj.to_ordered_dict(skip_missing=skip_missing, copy=copy)
+    return obj.to_ordered_dict(skip_missing=skip_missing, deepcopy=deepcopy)
 
 
 def transpose(

--- a/muspy/outputs/json.py
+++ b/muspy/outputs/json.py
@@ -29,5 +29,5 @@ def save_json(
 
     """
     with open(str(path), "w", encoding="utf-8") as f:
-        data = music.to_ordered_dict()
+        data = music.to_ordered_dict(copy=False)
         json.dump(data, f, ensure_ascii=ensure_ascii, indent=indent)

--- a/muspy/outputs/json.py
+++ b/muspy/outputs/json.py
@@ -32,7 +32,7 @@ def save_json(
         Keyword arguments to pass to :py:func:`json.dumps`.
 
     """
-    ordered_dict = music.to_ordered_dict(skip_missing=skip_missing, copy=False)
+    ordered_dict = music.to_ordered_dict(skip_missing=skip_missing)
     data = json.dumps(ordered_dict, ensure_ascii=ensure_ascii, **kwargs)
 
     if isinstance(path, (str, Path)):

--- a/muspy/outputs/json.py
+++ b/muspy/outputs/json.py
@@ -32,8 +32,11 @@ def save_json(
         Keyword arguments to pass to :py:func:`json.dumps`.
 
     """
-    ordered_dict = music.to_ordered_dict(skip_missing=skip_missing)
-    data = json.dumps(ordered_dict, ensure_ascii=ensure_ascii, **kwargs)
+    data = json.dumps(
+        music.to_ordered_dict(skip_missing=skip_missing, deepcopy=False),
+        ensure_ascii=ensure_ascii,
+        **kwargs
+    )
 
     if isinstance(path, (str, Path)):
         with open(str(path), "w", encoding="utf-8") as f:

--- a/muspy/outputs/yaml.py
+++ b/muspy/outputs/yaml.py
@@ -33,8 +33,11 @@ def save_yaml(
         Keyword arguments to pass to :py:func:`json.dumps`.
 
     """
-    ordered_dict = music.to_ordered_dict(skip_missing=skip_missing)
-    data = yaml_dump(ordered_dict, allow_unicode=allow_unicode, **kwargs)
+    data = yaml_dump(
+        music.to_ordered_dict(skip_missing=skip_missing, deepcopy=False),
+        allow_unicode=allow_unicode,
+        **kwargs
+    )
 
     if isinstance(path, (str, Path)):
         with open(str(path), "w", encoding="utf-8") as f:

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -48,7 +48,7 @@ def test_extend_copy():
         Note(time=1, duration=1, pitch=60),
         Note(time=2, duration=1, pitch=60),
     ]
-    track.extend(notes, copy=True)
+    track.extend(notes, deepcopy=True)
     assert track.notes[1:] == notes
     for a, b in zip(track.notes[1:], notes):
         assert a is not b

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -30,22 +30,39 @@ def test_append():
 
 
 def test_extend():
-    track = Track()
-    notes = [Note(time=0, duration=1, pitch=60), Note(time=1, duration=1, pitch=60)]
+    track = Track(notes=[Note(time=2, duration=1, pitch=60)])
+    notes = [Note(time=1, duration=1, pitch=60), Note(time=2, duration=1, pitch=60)]
     track.extend(notes)
-    assert len(track) == 2
-    assert len(track.notes) == 2
-    for a, b in zip(track.notes, notes):
+    assert len(track) == 1 + len(notes)
+    assert track.notes[1:] == notes
+    for a, b in zip(track.notes[1:], notes):
         assert a is b
 
 
 def test_extend_copy():
-    track = Track()
-    notes = [Note(time=0, duration=1, pitch=60), Note(time=1, duration=1, pitch=60)]
+    track = Track(notes=[Note(time=2, duration=1, pitch=60)])
+    notes = [Note(time=1, duration=1, pitch=60), Note(time=2, duration=1, pitch=60)]
     track.extend(notes, copy=True)
-    assert len(track.notes) == 2
-    for a, b in zip(track.notes, notes):
-        assert a == b
+    assert track.notes[1:] == notes
+    for a, b in zip(track.notes[1:], notes):
+        assert a is not b
+
+
+def test_iadd():
+    track = Track(notes=[Note(time=2, duration=1, pitch=60)])
+    notes = [Note(time=1, duration=1, pitch=60), Note(time=2, duration=1, pitch=60)]
+    track += notes
+    assert track.notes[1:] == notes
+    for a, b in zip(track.notes[1:], notes):
+        assert a is b
+
+
+def test_add_obj():
+    track1 = Track(notes=[Note(time=0, duration=1, pitch=60)])
+    track2 = Track(notes=[Note(time=1, duration=1, pitch=60), Note(time=2, duration=1, pitch=60)])
+    merged = track1 + track2
+    assert merged.notes == track1.notes + track2.notes
+    for a, b in zip(merged.notes, track1.notes + track2.notes):
         assert a is not b
 
 

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -29,6 +29,26 @@ def test_append():
     assert len(track) == 2
 
 
+def test_extend():
+    track = Track()
+    notes = [Note(time=0, duration=1, pitch=60), Note(time=1, duration=1, pitch=60)]
+    track.extend(notes)
+    assert len(track) == 2
+    assert len(track.notes) == 2
+    for a, b in zip(track.notes, notes):
+        assert a is b
+
+
+def test_extend_copy():
+    track = Track()
+    notes = [Note(time=0, duration=1, pitch=60), Note(time=1, duration=1, pitch=60)]
+    track.extend(notes, copy=True)
+    assert len(track.notes) == 2
+    for a, b in zip(track.notes, notes):
+        assert a == b
+        assert a is not b
+
+
 def test_remove_invalid():
     notes = [
         Note(time=-1, duration=1, pitch=60),

--- a/tests/test_music.py
+++ b/tests/test_music.py
@@ -2,9 +2,9 @@
 from copy import deepcopy
 from inspect import isclass
 from operator import attrgetter
-from muspy.base import ComplexBase
 
 import muspy
+from muspy.base import ComplexBase
 
 from .utils import TEST_JSON_PATH, check_tracks
 
@@ -92,7 +92,7 @@ def test_obj_extend():
 def test_obj_extend_no_copy():
     music = muspy.load(TEST_JSON_PATH)
     music2 = deepcopy(music).transpose(2)
-    music.extend(music2, copy=False)
+    music.extend(music2, deepcopy=False)
 
     for attr in music._list_attributes:
         g = attrgetter(attr)


### PR DESCRIPTION
This PR adds support for merging MusPy objects. One situation where this might be useful is when we want to merge events from two different tracks, maybe because they were in two different channels in the MIDI file, but logically they are the same track.

Changes:
- Adding a `Base.merge` method which recursively merges an object into `self`. Works similarly to the [`MergeFrom`](https://googleapis.dev/python/protobuf/latest/google/protobuf/message.html#google.protobuf.message.Message.MergeFrom) method of protocol buffers. It also sorts and removes duplicates from lists by default. We can also just merge a single attribute if we want to.
- Adding `+` and `+=` operators that call `merge` (the former making a deep copy first).
- Adding a `__deepcopy__` implementation by converting to a dict and back (somewhat faster than the built-in way).
- Fixing `to_ordered_dict` to create a deep copy of non-MusPy objects ~~(though I think this just means lists of primitive values, so they're shallow copies really)~~.
- Making `sort` also sort primitive types.

Not sure if it's useful to be able to merge objects of different types, or if we should throw an exception in that case.

A problem with `remove_duplicates` (apart from #32): It's only defined for `ComplexBase`, so for example it doesn't work for `metadata.creators`. I had to add an exception in the tests because of this. That makes me wonder if `sort` and `remove_duplicates` should be moved to `Base` (since list attributes are not just a feature of `ComplexBase`).