### PR TITLE
Adjust end time, not duration in adjust_time

### DIFF
--- a/muspy/classes.py
+++ b/muspy/classes.py
@@ -328,6 +328,12 @@ class Note(Base):
         if attr == "velocity" and (self.velocity < 0 or self.velocity > 127):
             raise ValueError("`velocity` must be in between 0 to 127.")
 
+    def _adjust_time(
+        self, func: Callable[[int], int], attr: str, recursive: bool
+    ):
+        # Implemented in adjust_time directly
+        raise NotImplementedError()
+
     def adjust_time(
         self,
         func: Callable[[int], int],
@@ -476,6 +482,12 @@ class Chord(Base):
             raise ValueError("`duration` must be nonnegative.")
         if attr == "velocity" and (self.velocity < 0 or self.velocity > 127):
             raise ValueError("`velocity` must be in between 0 to 127.")
+
+    def _adjust_time(
+        self, func: Callable[[int], int], attr: str, recursive: bool
+    ):
+        # Implemented in adjust_time directly
+        raise NotImplementedError()
 
     def adjust_time(
         self,

--- a/muspy/classes.py
+++ b/muspy/classes.py
@@ -332,9 +332,9 @@ class Note(Base):
         self, func: Callable[[int], int], attr: str, recursive: bool
     ):
         if attr == "time":
-            self.time = func(self.time)
-        elif attr == "duration":
-            self.end = func(self.end)
+            old_time = self.time
+            self.time = func(old_time)
+            self.duration = func(old_time + self.duration) - self.time
 
     def transpose(self, semitone: int) -> "Note":
         """Transpose the note by a number of semitones.
@@ -457,9 +457,9 @@ class Chord(Base):
         self, func: Callable[[int], int], attr: str, recursive: bool
     ):
         if attr == "time":
-            self.time = func(self.time)
-        elif attr == "duration":
-            self.end = func(self.end)
+            old_time = self.time
+            self.time = func(old_time)
+            self.duration = func(old_time + self.duration) - self.time
 
     def transpose(self, semitone: int) -> "Chord":
         """Transpose the notes by a number of semitones.

--- a/muspy/classes.py
+++ b/muspy/classes.py
@@ -328,13 +328,37 @@ class Note(Base):
         if attr == "velocity" and (self.velocity < 0 or self.velocity > 127):
             raise ValueError("`velocity` must be in between 0 to 127.")
 
-    def _adjust_time(
-        self, func: Callable[[int], int], attr: str, recursive: bool
-    ):
-        if attr == "time":
-            old_time = self.time
-            self.time = func(old_time)
-            self.duration = func(old_time + self.duration) - self.time
+    def adjust_time(
+        self,
+        func: Callable[[int], int],
+        attr: Optional[str] = None,
+        recursive: bool = True,
+    ) -> "Note":
+        """Adjust the timing of the note.
+
+        Parameters
+        ----------
+        func : callable
+            The function used to compute the new timing from the old
+            timing, i.e., `new_time = func(old_time)`.
+        attr : str
+            Attribute to adjust. Defaults to adjust all attributes.
+        recursive : bool
+            Whether to apply recursively. Defaults to True.
+
+        Returns
+        -------
+        Object itself.
+
+        """
+        if attr is not None and attr != 'time':
+            raise RuntimeError('Cannot adjust attribute ' + repr(attr))
+
+        old_time = self.time
+        self.time = func(old_time)
+        self.duration = func(old_time + self.duration) - self.time
+
+        return self
 
     def transpose(self, semitone: int) -> "Note":
         """Transpose the note by a number of semitones.
@@ -453,13 +477,37 @@ class Chord(Base):
         if attr == "velocity" and (self.velocity < 0 or self.velocity > 127):
             raise ValueError("`velocity` must be in between 0 to 127.")
 
-    def _adjust_time(
-        self, func: Callable[[int], int], attr: str, recursive: bool
-    ):
-        if attr == "time":
-            old_time = self.time
-            self.time = func(old_time)
-            self.duration = func(old_time + self.duration) - self.time
+    def adjust_time(
+        self,
+        func: Callable[[int], int],
+        attr: Optional[str] = None,
+        recursive: bool = True,
+    ) -> "Chord":
+        """Adjust the timing of the chord.
+
+        Parameters
+        ----------
+        func : callable
+            The function used to compute the new timing from the old
+            timing, i.e., `new_time = func(old_time)`.
+        attr : str
+            Attribute to adjust. Defaults to adjust all attributes.
+        recursive : bool
+            Whether to apply recursively. Defaults to True.
+
+        Returns
+        -------
+        Object itself.
+
+        """
+        if attr is not None and attr != 'time':
+            raise RuntimeError('Cannot adjust attribute ' + repr(attr))
+
+        old_time = self.time
+        self.time = func(old_time)
+        self.duration = func(old_time + self.duration) - self.time
+
+        return self
 
     def transpose(self, semitone: int) -> "Chord":
         """Transpose the notes by a number of semitones.

--- a/muspy/classes.py
+++ b/muspy/classes.py
@@ -334,7 +334,7 @@ class Note(Base):
         if attr == "time":
             self.time = func(self.time)
         elif attr == "duration":
-            self.duration = func(self.duration)
+            self.end = func(self.end)
 
     def transpose(self, semitone: int) -> "Note":
         """Transpose the note by a number of semitones.
@@ -459,7 +459,7 @@ class Chord(Base):
         if attr == "time":
             self.time = func(self.time)
         elif attr == "duration":
-            self.duration = func(self.duration)
+            self.end = func(self.end)
 
     def transpose(self, semitone: int) -> "Chord":
         """Transpose the notes by a number of semitones.

--- a/muspy/classes.py
+++ b/muspy/classes.py
@@ -331,8 +331,7 @@ class Note(Base):
     def _adjust_time(
         self, func: Callable[[int], int], attr: str, recursive: bool
     ):
-        # Implemented in adjust_time directly
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def adjust_time(
         self,
@@ -357,13 +356,12 @@ class Note(Base):
         Object itself.
 
         """
-        if attr is not None and attr != 'time':
-            raise RuntimeError('Cannot adjust attribute ' + repr(attr))
+        if attr is not None and attr != "time":
+            raise AttributeError(f"'Note' object has no attribute '{attr}'")
 
         old_time = self.time
-        self.time = func(old_time)
+        self.time = func(self.time)
         self.duration = func(old_time + self.duration) - self.time
-
         return self
 
     def transpose(self, semitone: int) -> "Note":
@@ -486,8 +484,7 @@ class Chord(Base):
     def _adjust_time(
         self, func: Callable[[int], int], attr: str, recursive: bool
     ):
-        # Implemented in adjust_time directly
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def adjust_time(
         self,
@@ -512,13 +509,12 @@ class Chord(Base):
         Object itself.
 
         """
-        if attr is not None and attr != 'time':
-            raise RuntimeError('Cannot adjust attribute ' + repr(attr))
+        if attr is not None and attr != "time":
+            raise AttributeError(f"'Note' object has no attribute '{attr}'")
 
         old_time = self.time
-        self.time = func(old_time)
+        self.time = func(self.time)
         self.duration = func(old_time + self.duration) - self.time
-
         return self
 
     def transpose(self, semitone: int) -> "Chord":


### PR DESCRIPTION
We want `func` to be applied to absolute timestamps, not durations.