### PR TITLE
Reduce number of len calls

### DIFF
--- a/muspy/music.py
+++ b/muspy/music.py
@@ -247,8 +247,9 @@ class Music(ComplexBase):
 
         """
         beats: List[Beat] = []
+        last_index_time_signatures: int = len(self.time_signatures) - 1
         for i, time_sign in enumerate(self.time_signatures):
-            if i == len(self.time_signatures) - 1:
+            if i == last_index_time_signatures:
                 end = self.get_end_time()
             else:
                 end = self.time_signatures[i + 1].time


### PR DESCRIPTION
Hey, I was looking through the source code and happened to come across this really small efficiency improvement opportunity. Basically instead of getting the length of the iterable every iteration and subtracting one from it to get the last index, I thought it may be better to calculate it outside the for-in loop.
First time here 👀 