### PR TITLE
Fix key signature conversion when mode is missing

### DIFF
--- a/muspy/outputs/music21.py
+++ b/muspy/outputs/music21.py
@@ -37,11 +37,14 @@ def to_music21_key(key_signature: KeySignature) -> Key:
     elif key_signature.root is not None:
         tonic = PITCH_NAMES[key_signature.root]
     elif key_signature.fifths is not None:
-        if key_signature.mode is not None:
-            offset = MODE_CENTERS[key_signature.mode]
-            tonic = CIRCLE_OF_FIFTHS[key_signature.fifths + offset][1]
-        else:
-            tonic = CIRCLE_OF_FIFTHS[key_signature.fifths][1]
+        # `fifths` is the number of sharps/flats (positive for sharps).
+        # Convert it to a position on the circle of fifths by adding the
+        # mode offset. Default to the major offset when the mode is missing
+        # (e.g. key signatures parsed from MuseScore files).
+        offset = MODE_CENTERS.get(
+            key_signature.mode, MODE_CENTERS["major"]
+        )
+        tonic = CIRCLE_OF_FIFTHS[key_signature.fifths + offset][1]
     else:
         raise ValueError(
             "One of `root`, `root_str` or `fifths` must be specified."

--- a/tests/test_music21.py
+++ b/tests/test_music21.py
@@ -47,3 +47,29 @@ def test_music21_realworld():
     assert len(music.time_signatures) == 2  # Due to the repeat
     assert music.time_signatures[0].numerator == 3
     assert music.time_signatures[0].denominator == 8
+
+
+def test_to_music21_key_fifths_without_mode():
+    """fifths (number of sharps/flats) must map correctly even when mode is None.
+
+    Regression test: the previous code used ``CIRCLE_OF_FIFTHS[fifths]`` directly
+    (missing the mode offset), so e.g. fifths=1 (G major, one sharp) was written
+    as Cb major.
+    """
+    from muspy import KeySignature
+    from muspy.outputs.music21 import to_music21_key
+
+    cases = [
+        (0, None, "C"),
+        (1, None, "G"),
+        (-1, None, "F"),
+        (2, "major", "D"),
+        (-5, "major", "D-"),
+        (1, "minor", "E"),
+        (-5, "minor", "B-"),
+    ]
+    for fifths, mode, expected in cases:
+        key = to_music21_key(KeySignature(time=0, fifths=fifths, mode=mode))
+        assert key.tonic.name == expected, (
+            f"fifths={fifths}, mode={mode} -> {key.tonic.name}, expected {expected}"
+        )


### PR DESCRIPTION
to_music21_key previously used CIRCLE_OF_FIFTHS[fifths] directly when mode was None, treating the number of sharps/flats as a circle-of-fifths index. This produced wrong tonics (e.g. fifths=1 / one sharp was written as Cb major instead of G major).

Default to the major mode offset (MODE_CENTERS['major']) when mode is not given, matching how fifths is interpreted elsewhere in the codebase.

Fixes a case commonly hit when converting MuseScore-derived data that stores key signatures as fifths only.